### PR TITLE
Alpine Python Install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,8 @@
-FROM ubuntu:14.04
+FROM python:3.5-alpine
 
 MAINTAINER Arthur Blair <adblair@gmail.com>
 
-ADD https://bootstrap.pypa.io/get-pip.py /get-pip.py
-
-RUN python3 /get-pip.py
-
-RUN pip install devpi-server==2.3.1 devpi-web==2.4.1
+RUN ["pip", "install", "--no-cache-dir", "devpi-server==3.0.1"]
 
 EXPOSE 3141
 


### PR DESCRIPTION
Using the `python:3.5-alpine` base image eliminates the need to install pip directly, and makes for a smaller image.

```
$ docker images | grep devpi
adblair/devpi-server                    alpine              a4977121ec0b        51 minutes ago      106.7 MB
adblair/devpi-server                    latest              3e18a17910a3        4 months ago        233.6 MB
```
